### PR TITLE
Only use the typed data interface for Ruby version >= 2.2.0

### DIFF
--- a/ext/openssl/cipher/aead/aead.c
+++ b/ext/openssl/cipher/aead/aead.c
@@ -1,17 +1,25 @@
 #include <ruby.h>
+#include <ruby/version.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
 VALUE dOSSL;
 VALUE eCipherError;
 
+#if RUBY_API_VERSION_CODE >= 20200
 #define GetCipherInit(obj, ctx) do { \
     TypedData_Get_Struct((obj), EVP_CIPHER_CTX, RTYPEDDATA_TYPE(obj), (ctx)); \
 } while (0)
-#define GetCipher(obj, ctx) do { \
-    GetCipherInit((obj), (ctx)); \
-    if (!(ctx)) { \
-	ossl_raise(rb_eRuntimeError, "Cipher not inititalized!"); \
+#else
+#define GetCipherInit(obj, ctx) do {                \
+    Data_Get_Struct((obj), EVP_CIPHER_CTX, (ctx));  \
+} while (0)
+#endif
+
+#define GetCipher(obj, ctx) do {                                  \
+    GetCipherInit((obj), (ctx));                                  \
+    if (!(ctx)) {                                                 \
+        ossl_raise(rb_eRuntimeError, "Cipher not inititalized!"); \
     } \
 } while (0)
 


### PR DESCRIPTION
Addresses concern in https://github.com/onelogin/aead/pull/10#issuecomment-225605263

Gist of the change:
- Ruby exposes a `RUBY_API_VERSION_CODE` constant in `ruby/version.h`
- I asserted the versions that includes the changeset that introduces typed_data to the openssl extension ( https://github.com/ruby/ruby/commit/163cb5b43de68cef7ae4fa053d710098399d1359 )

```
Lourenss-Air:ruby lourens$ git tag --contains 163cb5b43de68cef7ae4fa053d710098399d1359
v2_2_0
v2_2_0_preview2
v2_2_0_rc1
v2_2_1
v2_2_2
v2_2_3
v2_2_4
v2_2_5
v2_3_0
v2_3_0_preview1
v2_3_0_preview2
v2_3_1
```

I think it's OK to skip `v2_2_0_preview2` and `v2_2_0_rc1` and standardise on `v2_2_0` as the version that should start using the typed_data interface for this extension.

@pallan @csfrancis @jnormore @stonith 
